### PR TITLE
[Author] Implement API extension

### DIFF
--- a/src/main/java/com/samples/spring/boundary/QlAuthorBlogPostAssignmentController.java
+++ b/src/main/java/com/samples/spring/boundary/QlAuthorBlogPostAssignmentController.java
@@ -1,7 +1,7 @@
 package com.samples.spring.boundary;
 
 import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.stereotype.Controller;
 
 import com.samples.spring.domain.AuthorsService;
@@ -29,7 +29,7 @@ public class QlAuthorBlogPostAssignmentController {
     this.mapper = mapper;
   }
 
-  @QueryMapping("assignAuthorToBlogPost")
+  @MutationMapping("assignAuthorToBlogPost")
   public QlBlogPostDto assignAuthorToBlogPost(
       @Valid
       @Argument("input")

--- a/src/main/java/com/samples/spring/boundary/QlAuthorBlogPostAssignmentController.java
+++ b/src/main/java/com/samples/spring/boundary/QlAuthorBlogPostAssignmentController.java
@@ -1,0 +1,49 @@
+package com.samples.spring.boundary;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import com.samples.spring.domain.AuthorsService;
+import com.samples.spring.domain.BlogPostsService;
+
+import jakarta.validation.Valid;
+
+@Controller
+public class QlAuthorBlogPostAssignmentController {
+
+  // TODO create assignment service in domain
+  
+  private final BlogPostsService blogPostsService;
+  private final AuthorsService authorsService;
+  private final QlBlogPostDtoMapper mapper;
+  
+  public QlAuthorBlogPostAssignmentController(
+      BlogPostsService blogPostsService, 
+      AuthorsService authorsService,
+      QlBlogPostDtoMapper mapper
+  ) {
+    super();
+    this.blogPostsService = blogPostsService;
+    this.authorsService = authorsService;
+    this.mapper = mapper;
+  }
+
+  @QueryMapping("assignAuthorToBlogPost")
+  public QlBlogPostDto assignAuthorToBlogPost(
+      @Valid
+      @Argument("input")
+      QlBlogPostAuthorAssignmentInputDto input
+  ) {
+    var author = authorsService
+        .findById(input.authorId())
+        .get(); // else throw exception that leads to GraphQlError
+    var blogPost = blogPostsService
+        .findById(input.blogPostId())
+        .get(); // else throw exception that leads to GraphQlError
+    blogPost.setAuthor(author);
+    blogPostsService.update(blogPost);
+    return mapper.map(blogPost);
+  }
+  
+}

--- a/src/main/java/com/samples/spring/boundary/QlAuthorDto.java
+++ b/src/main/java/com/samples/spring/boundary/QlAuthorDto.java
@@ -1,0 +1,13 @@
+package com.samples.spring.boundary;
+
+import java.util.UUID;
+
+public record QlAuthorDto(
+    
+    UUID id,
+    String firstName,
+    String lastName
+    
+) {
+
+}

--- a/src/main/java/com/samples/spring/boundary/QlAuthorDtoMapper.java
+++ b/src/main/java/com/samples/spring/boundary/QlAuthorDtoMapper.java
@@ -1,0 +1,18 @@
+package com.samples.spring.boundary;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.samples.spring.domain.Author;
+
+@Mapper(componentModel = "spring")
+public interface QlAuthorDtoMapper {
+
+  QlAuthorDto map(Author source);
+  
+  Author map(QlAuthorDto source);
+  
+  @Mapping(target = "id", ignore = true)
+  Author map(QlAuthorInputDto source);
+  
+}

--- a/src/main/java/com/samples/spring/boundary/QlAuthorInputDto.java
+++ b/src/main/java/com/samples/spring/boundary/QlAuthorInputDto.java
@@ -1,0 +1,14 @@
+package com.samples.spring.boundary;
+
+import jakarta.validation.constraints.Size;
+
+public record QlAuthorInputDto(
+    
+    @Size(min = 1, max = 50)
+    String firstName,
+    @Size(min = 1, max = 50)
+    String lastName
+    
+) {
+
+}

--- a/src/main/java/com/samples/spring/boundary/QlAuthorsController.java
+++ b/src/main/java/com/samples/spring/boundary/QlAuthorsController.java
@@ -1,0 +1,62 @@
+package com.samples.spring.boundary;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+import com.samples.spring.domain.AuthorsService;
+
+import jakarta.validation.Valid;
+
+@Controller
+public class QlAuthorsController {
+
+  private final AuthorsService service;
+  private final QlAuthorDtoMapper mapper;
+
+  public QlAuthorsController(
+      AuthorsService service, 
+      QlAuthorDtoMapper mapper
+  ) {
+    super();
+    this.service = service;
+    this.mapper = mapper;
+  }
+  
+  // GraphQl implementation
+
+  @QueryMapping("findAllAuthors")
+  public Stream<QlAuthorDto> findAllAuthors() {
+      return service
+          .findAll()
+          .map(mapper::map);
+  }
+  
+  @QueryMapping("findAuthorById")
+  public QlAuthorDto findAuthorById(
+    @Argument("id")
+    UUID id
+  ) {
+    return service
+        .findById(id)
+        .map(mapper::map)
+        .orElse(null);
+  }
+  
+  @MutationMapping("createAuthor")
+  public QlAuthorDto createAuthor(
+    @Valid
+    @Argument("input")
+    QlAuthorInputDto input
+  ) {
+    var author = mapper.map(input);
+    service.create(author);
+    var responseDto = mapper.map(author);
+    return responseDto;
+  }
+  
+}

--- a/src/main/java/com/samples/spring/boundary/QlBlogPostAuthorAssignmentInputDto.java
+++ b/src/main/java/com/samples/spring/boundary/QlBlogPostAuthorAssignmentInputDto.java
@@ -1,0 +1,16 @@
+package com.samples.spring.boundary;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+public record QlBlogPostAuthorAssignmentInputDto(
+
+    @NotNull
+    UUID blogPostId,
+    @NotNull
+    UUID authorId
+    
+) {
+
+}

--- a/src/main/java/com/samples/spring/boundary/QlBlogPostDto.java
+++ b/src/main/java/com/samples/spring/boundary/QlBlogPostDto.java
@@ -8,7 +8,8 @@ public record QlBlogPostDto(
     UUID id,
     String title,
     String content,
-    ZonedDateTime created
+    ZonedDateTime created,
+    QlAuthorDto author
     
 ) {
 

--- a/src/main/java/com/samples/spring/boundary/QlBlogPostDtoMapper.java
+++ b/src/main/java/com/samples/spring/boundary/QlBlogPostDtoMapper.java
@@ -5,7 +5,10 @@ import org.mapstruct.Mapping;
 
 import com.samples.spring.domain.BlogPost;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    uses = QlAuthorDtoMapper.class
+)
 public interface QlBlogPostDtoMapper {
 
   QlBlogPostDto map(BlogPost source);

--- a/src/main/java/com/samples/spring/domain/Author.java
+++ b/src/main/java/com/samples/spring/domain/Author.java
@@ -1,0 +1,36 @@
+package com.samples.spring.domain;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.Size;
+
+public class Author {
+
+  private UUID id;
+  @Size(min = 1, max = 50)
+  private String firstName;
+  @Size(min = 1, max = 50)
+  private String lastName;
+
+  public UUID getId() {
+    return id;
+  }
+  public void setId(UUID id) {
+    this.id = id;
+  }
+  public String getFirstName() {
+    return firstName;
+  }
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+  public String getLastName() {
+    return lastName;
+  }
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+  
+  
+  
+}

--- a/src/main/java/com/samples/spring/domain/AuthorCreatedEvent.java
+++ b/src/main/java/com/samples/spring/domain/AuthorCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.samples.spring.domain;
+
+public record AuthorCreatedEvent(
+    Author author
+) {
+
+}

--- a/src/main/java/com/samples/spring/domain/AuthorsService.java
+++ b/src/main/java/com/samples/spring/domain/AuthorsService.java
@@ -1,0 +1,38 @@
+package com.samples.spring.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+import com.samples.spring.shared.events.PublishEvent;
+
+import jakarta.validation.Valid;
+
+@Validated
+@Service
+public class AuthorsService {
+  
+  private final AuthorsSink sink;
+  
+  public AuthorsService(AuthorsSink sink) {
+    super();
+    this.sink = sink;
+  }
+
+  public Stream<Author> findAll() {
+    return sink.findAll();
+  }
+
+  public Optional<Author> findById(UUID id) {
+    return sink.findById(id);
+  }
+
+  @PublishEvent(AuthorCreatedEvent.class)
+  public void create(@Valid Author author) {
+     sink.create(author);
+  }
+
+}

--- a/src/main/java/com/samples/spring/domain/AuthorsSink.java
+++ b/src/main/java/com/samples/spring/domain/AuthorsSink.java
@@ -1,0 +1,23 @@
+package com.samples.spring.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+public interface AuthorsSink {
+
+  Stream<Author> findAll();
+
+  default Optional<Author> findById(UUID id) {
+    return findAll()
+        .filter(author -> id.equals(author.getId()))
+        .findFirst();
+  }
+  
+  void create(Author newPost);
+  
+  default boolean existsById(UUID id) {
+    return findById(id)
+        .isPresent();
+  }
+}

--- a/src/main/java/com/samples/spring/domain/BlogPost.java
+++ b/src/main/java/com/samples/spring/domain/BlogPost.java
@@ -16,6 +16,7 @@ public class BlogPost {
   @Size(min = 4, max = 1000)
   private String content;
   private ZonedDateTime created;
+  private Author author;
 
   public static BlogPost valueOf(String title, String content) {
     var result = new BlogPost();
@@ -47,6 +48,12 @@ public class BlogPost {
   }
   public void setCreated(ZonedDateTime created) {
     this.created = created;
+  }
+  public Author getAuthor() {
+    return author;
+  }
+  public void setAuthor(Author author) {
+    this.author = author;
   }
   
 }

--- a/src/main/java/com/samples/spring/domain/BlogPostUpdatedEvent.java
+++ b/src/main/java/com/samples/spring/domain/BlogPostUpdatedEvent.java
@@ -1,0 +1,7 @@
+package com.samples.spring.domain;
+
+public record BlogPostUpdatedEvent(
+    BlogPost blogPost
+) {
+
+}

--- a/src/main/java/com/samples/spring/domain/BlogPostsService.java
+++ b/src/main/java/com/samples/spring/domain/BlogPostsService.java
@@ -35,6 +35,14 @@ public class BlogPostsService {
     sink.create(newPost);
   }
 
+  @PublishEvent(BlogPostUpdatedEvent.class)
+  public void update(@Valid BlogPost blogPost) {
+    if(!exists(blogPost.getId())) {
+      throw new BlogPostNotFoundException(blogPost.getId());
+    }
+    sink.update(blogPost);    
+  }
+
   public boolean exists(UUID id) {
     return sink.existsById(id);
   }
@@ -49,5 +57,5 @@ public class BlogPostsService {
   public long count() {
     return sink.count();
   }
-  
+
 }

--- a/src/main/java/com/samples/spring/domain/BlogPostsSink.java
+++ b/src/main/java/com/samples/spring/domain/BlogPostsSink.java
@@ -16,6 +16,8 @@ public interface BlogPostsSink {
   
   void create(BlogPost newPost);
   
+  void update(BlogPost blogPost);
+
   boolean delete(UUID id);
 
   default long count() {
@@ -27,4 +29,5 @@ public interface BlogPostsSink {
     return findById(id)
         .isPresent();
   }
+
 }

--- a/src/main/java/com/samples/spring/persistence/jpa/AuthorEntity.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/AuthorEntity.java
@@ -1,0 +1,45 @@
+package com.samples.spring.persistence.jpa;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+
+@Table(name = "AUTHORS")
+@Entity(name = "Author")
+public class AuthorEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+  @Size(min = 1, max = 50)
+  private String firstName;
+  @Size(min = 1, max = 50)
+  private String lastName;
+
+  public UUID getId() {
+    return id;
+  }
+  public void setId(UUID id) {
+    this.id = id;
+  }
+  public String getFirstName() {
+    return firstName;
+  }
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+  public String getLastName() {
+    return lastName;
+  }
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+  
+  
+  
+}

--- a/src/main/java/com/samples/spring/persistence/jpa/AuthorEntityMapper.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/AuthorEntityMapper.java
@@ -1,0 +1,17 @@
+package com.samples.spring.persistence.jpa;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+
+import com.samples.spring.domain.Author;
+
+@Mapper(componentModel = "spring")
+public interface AuthorEntityMapper {
+  
+  AuthorEntity map(Author source);
+  
+  Author map(AuthorEntity source);
+  
+  void copy(AuthorEntity source, @MappingTarget Author target);
+
+}

--- a/src/main/java/com/samples/spring/persistence/jpa/AuthorEntityRepository.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/AuthorEntityRepository.java
@@ -1,0 +1,12 @@
+package com.samples.spring.persistence.jpa;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuthorEntityRepository
+  extends JpaRepository<AuthorEntity, UUID>{
+
+}

--- a/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntity.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -28,6 +29,8 @@ public class BlogPostEntity {
   private String content;
   @Column(name = "CREATION_DATE")
   private ZonedDateTime created;
+  @ManyToOne // default fetch type is eager, no cascading
+  private AuthorEntity author;
 
   @PrePersist
   void updateCreated() {
@@ -59,6 +62,12 @@ public class BlogPostEntity {
   }
   public void setCreated(ZonedDateTime created) {
     this.created = created;
+  }
+  public AuthorEntity getAuthor() {
+    return author;
+  }
+  public void setAuthor(AuthorEntity author) {
+    this.author = author;
   }
   
 }

--- a/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntityMapper.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntityMapper.java
@@ -5,7 +5,10 @@ import org.mapstruct.MappingTarget;
 
 import com.samples.spring.domain.BlogPost;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    uses = AuthorEntityMapper.class
+)
 public interface BlogPostEntityMapper {
 
   BlogPostEntity map (BlogPost source);

--- a/src/main/java/com/samples/spring/persistence/jpa/JpaAuthorsSink.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/JpaAuthorsSink.java
@@ -1,0 +1,53 @@
+package com.samples.spring.persistence.jpa;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import com.samples.spring.domain.Author;
+import com.samples.spring.domain.AuthorsSink;
+
+class JpaAuthorsSink
+  implements AuthorsSink {
+
+  private final AuthorEntityRepository repo;
+  private final AuthorEntityMapper mapper;
+  
+  public JpaAuthorsSink(
+      AuthorEntityRepository repo, 
+      AuthorEntityMapper mapper
+  ) {
+    super();
+    this.repo = repo;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Stream<Author> findAll() {
+    return repo
+        .findAll()
+        .stream()
+        .map(mapper::map);
+  }
+
+  @Override
+  public Optional<Author> findById(UUID id) {
+    return repo
+        .findById(id)
+        .map(mapper::map);
+  }
+
+  @Override
+  public void create(Author newPost) {
+    var entity = mapper.map(newPost);
+    repo.save(entity);
+    mapper.copy(entity, newPost);
+  }
+
+  @Override
+  public boolean existsById(UUID id) {
+    return repo
+        .existsById(id);
+  }
+
+}

--- a/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSink.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSink.java
@@ -45,6 +45,13 @@ class JpaBlogPostsSink
   }
 
   @Override
+  public void update(BlogPost blogPost) {
+    var entity = mapper.map(blogPost);
+    repo.save(entity);
+    mapper.copy(entity, blogPost);
+  }
+  
+  @Override
   public boolean delete(UUID id) {
     if(!repo.existsById(id)) {
       return false;

--- a/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSinkConfiguration.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSinkConfiguration.java
@@ -2,6 +2,7 @@ package com.samples.spring.persistence.jpa;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.samples.spring.domain.AuthorsSink;
 import com.samples.spring.domain.BlogPostsSink;
 
 @Configuration
@@ -14,6 +15,14 @@ public class JpaBlogPostsSinkConfiguration {
       BlogPostEntityMapper mapper
   ) {
     return new JpaBlogPostsSink(repo, mapper);
+  }
+  
+  @Bean
+  AuthorsSink jpaAuthorsSink(
+      AuthorEntityRepository repo,
+      AuthorEntityMapper mapper
+  ) {
+    return new JpaAuthorsSink(repo, mapper);
   }
   
 }

--- a/src/main/java/com/samples/spring/persistence/memory/InMemoryAuthorsSink.java
+++ b/src/main/java/com/samples/spring/persistence/memory/InMemoryAuthorsSink.java
@@ -1,0 +1,49 @@
+package com.samples.spring.persistence.memory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import com.samples.spring.domain.Author;
+import com.samples.spring.domain.AuthorsSink;
+
+class InMemoryAuthorsSink
+  implements AuthorsSink{
+
+  private final Map<UUID, Author> authors = new ConcurrentHashMap<>();
+
+  @Override
+  public Stream<Author> findAll() {
+    return this
+        .authors
+        .values()
+        .stream();
+  }
+
+  @Override
+  public Optional<Author> findById(UUID id) {
+    return Optional.ofNullable(
+        this
+          .authors
+          .get(id)
+      );
+  }
+
+  @Override
+  public void create(Author newPost) {
+    newPost.setId(UUID.randomUUID());
+    this
+      .authors
+      .put(newPost.getId(), newPost);
+  }
+
+  @Override
+  public boolean existsById(UUID id) {
+    return this
+        .authors
+        .containsKey(id);
+  }
+  
+}

--- a/src/main/java/com/samples/spring/persistence/memory/InMemoryBlogPostsSink.java
+++ b/src/main/java/com/samples/spring/persistence/memory/InMemoryBlogPostsSink.java
@@ -42,6 +42,13 @@ class InMemoryBlogPostsSink
   }
 
   @Override
+  public void update(BlogPost blogPost) {
+    this
+      .blogPosts
+      .put(blogPost.getId(), blogPost);
+  }
+  
+  @Override
   public boolean delete(UUID id) {
     return this
         .blogPosts
@@ -61,5 +68,5 @@ class InMemoryBlogPostsSink
         .blogPosts
         .containsKey(id);
   }
-  
+
 }

--- a/src/main/java/com/samples/spring/persistence/memory/InMemoryBlogPostsSinkConfiguration.java
+++ b/src/main/java/com/samples/spring/persistence/memory/InMemoryBlogPostsSinkConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.samples.spring.domain.AuthorsSink;
 import com.samples.spring.domain.BlogPostsSink;
 
 @Configuration
@@ -13,6 +14,12 @@ public class InMemoryBlogPostsSinkConfiguration {
   @Bean
   BlogPostsSink inMemoryBlogPostsSink() {
     return new InMemoryBlogPostsSink();
+  }
+  
+  @ConditionalOnMissingBean
+  @Bean
+  AuthorsSink inMemoryAuthorsSink() {
+    return new InMemoryAuthorsSink();
   }
   
 }

--- a/src/test/java/com/samples/spring/boundary/GraphQlAuthorsTests.java
+++ b/src/test/java/com/samples/spring/boundary/GraphQlAuthorsTests.java
@@ -1,5 +1,6 @@
 package com.samples.spring.boundary;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
@@ -7,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.graphql.test.tester.GraphQlTester;
 
+@Disabled
 @SpringBootTest
 @AutoConfigureGraphQlTester
 @AutoConfigureTestDatabase

--- a/src/test/java/com/samples/spring/boundary/GraphQlAuthorsTests.java
+++ b/src/test/java/com/samples/spring/boundary/GraphQlAuthorsTests.java
@@ -1,6 +1,4 @@
 package com.samples.spring.boundary;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
@@ -8,7 +6,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.graphql.test.tester.GraphQlTester;
 
-@Disabled
 @SpringBootTest
 @AutoConfigureGraphQlTester
 @AutoConfigureTestDatabase

--- a/src/test/java/com/samples/spring/boundary/GraphQlAuthorsTests.java
+++ b/src/test/java/com/samples/spring/boundary/GraphQlAuthorsTests.java
@@ -1,5 +1,5 @@
 package com.samples.spring.boundary;
-import org.junit.jupiter.api.Disabled;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.graphql.tester.AutoConfigureGraphQlTester;
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.graphql.test.tester.GraphQlTester;
 
-@Disabled
 @SpringBootTest
 @AutoConfigureGraphQlTester
 @AutoConfigureTestDatabase


### PR DESCRIPTION
This implementation uses references from `BlogPost` to `Author` in all layers.
- Domain Driven Design ✅
- JPA joins the tables, so there is no [Hibernate N+1 Problem](https://www.baeldung.com/spring-hibernate-n1-problem) ✅
- The authors are loaded along with the blogposts, regardless of whether the GraphQl query requires author data or not ⚠️