### PR TITLE
[Author] Optimize loading of authors only when requested

### DIFF
--- a/src/main/java/com/samples/spring/boundary/QlBlogPostsController.java
+++ b/src/main/java/com/samples/spring/boundary/QlBlogPostsController.java
@@ -8,8 +8,10 @@ import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
+import com.samples.spring.domain.BlogPostOptions;
 import com.samples.spring.domain.BlogPostsService;
 
+import graphql.schema.DataFetchingEnvironment;
 import jakarta.validation.Valid;
 
 @Controller
@@ -30,10 +32,15 @@ public class QlBlogPostsController {
   // GraphQl implementation
   
   @QueryMapping("findAllBlogPosts")
-  public Stream<QlBlogPostDto> findAllBlogPosts() {
-      return service
-          .findAll()
-          .map(mapper::map);
+  public Stream<QlBlogPostDto> findAllBlogPosts(DataFetchingEnvironment env) {
+    var authorRequested = env
+        .getSelectionSet()
+        .contains("author");
+    var options = new BlogPostOptions()
+        .withAuthor(authorRequested);
+    return service
+        .findAll(options)
+        .map(mapper::map);
   }
   
   @QueryMapping("findBlogPostById")

--- a/src/main/java/com/samples/spring/domain/BlogPostOptions.java
+++ b/src/main/java/com/samples/spring/domain/BlogPostOptions.java
@@ -1,0 +1,16 @@
+package com.samples.spring.domain;
+
+public class BlogPostOptions {
+  
+  private boolean author = true;
+  
+  public BlogPostOptions withAuthor(boolean author) {
+    this.author = author;
+    return this;
+  }
+
+  public boolean isAuthor() {
+    return author;
+  }
+
+}

--- a/src/main/java/com/samples/spring/domain/BlogPostsService.java
+++ b/src/main/java/com/samples/spring/domain/BlogPostsService.java
@@ -23,9 +23,13 @@ public class BlogPostsService {
   }
 
   public Stream<BlogPost> findAll() {
-    return sink.findAll();
+    return this.findAll(new BlogPostOptions());
   }
-  
+
+  public Stream<BlogPost> findAll(BlogPostOptions options) {
+    return sink.findAll(options);
+  }
+
   public Optional<BlogPost> findById(UUID id) {
     return sink.findById(id);
   }

--- a/src/main/java/com/samples/spring/domain/BlogPostsSink.java
+++ b/src/main/java/com/samples/spring/domain/BlogPostsSink.java
@@ -6,10 +6,12 @@ import java.util.stream.Stream;
 
 public interface BlogPostsSink {
 
-  Stream<BlogPost> findAll();
+  Stream<BlogPost> findAll(BlogPostOptions options);
 
-  default Optional<BlogPost> findById(UUID id) {
-    return findAll()
+  default Optional<BlogPost> findById(
+      UUID id
+  ) {
+    return findAll(new BlogPostOptions())
         .filter(bp -> id.equals(bp.getId()))
         .findFirst();
   }
@@ -21,7 +23,7 @@ public interface BlogPostsSink {
   boolean delete(UUID id);
 
   default long count() {
-    return findAll()
+    return findAll(new BlogPostOptions())
         .count();
   }
 

--- a/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntityMapper.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntityMapper.java
@@ -1,6 +1,7 @@
 package com.samples.spring.persistence.jpa;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import com.samples.spring.domain.BlogPost;
@@ -13,8 +14,18 @@ public interface BlogPostEntityMapper {
 
   BlogPostEntity map (BlogPost source);
 
+  // do not copy the author, if not loaded
+  @Mapping(
+      target = "author",
+      conditionExpression = "java(org.hibernate.Hibernate.isInitialized(source.getAuthor()))"
+  )
   BlogPost map (BlogPostEntity source);
 
+  // do not copy the author, if not loaded
+  @Mapping(
+      target = "author",
+      conditionExpression = "java(org.hibernate.Hibernate.isInitialized(source.getAuthor()))"
+  )
   void copy(BlogPostEntity source, @MappingTarget BlogPost target);
   
 }

--- a/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSink.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSink.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import com.samples.spring.domain.BlogPost;
+import com.samples.spring.domain.BlogPostOptions;
 import com.samples.spring.domain.BlogPostsSink;
 
 class JpaBlogPostsSink
@@ -12,20 +13,27 @@ class JpaBlogPostsSink
 
   private final BlogPostEntityRepository repo;
   private final BlogPostEntityMapper mapper;
+  private final JpaEntityGraphQueryBuilder queryBuilder;
   
   public JpaBlogPostsSink(
       BlogPostEntityRepository repo, 
-      BlogPostEntityMapper mapper
+      BlogPostEntityMapper mapper,
+      JpaEntityGraphQueryBuilder queryBuilder
   ) {
     super();
     this.repo = repo;
     this.mapper = mapper;
+    this.queryBuilder = queryBuilder;
   }
 
   @Override
-  public Stream<BlogPost> findAll() {
-    return repo
-        .findAll()
+  public Stream<BlogPost> findAll(BlogPostOptions options) {
+    // We build the EntityGraph dynamically here,
+    // so we could not use the repository pattern.
+    // otherwise, we could use: https://github.com/Cosium/spring-data-jpa-entity-graph
+    return queryBuilder
+        .findAllQuery(options)
+        .getResultList()
         .stream()
         .map(mapper::map);
   }

--- a/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSinkConfiguration.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/JpaBlogPostsSinkConfiguration.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import com.samples.spring.domain.AuthorsSink;
 import com.samples.spring.domain.BlogPostsSink;
 
+import jakarta.persistence.EntityManager;
+
 @Configuration
 // @ConditionalOnBean(BlogPostEntityRepository.class)
 public class JpaBlogPostsSinkConfiguration {
@@ -12,9 +14,10 @@ public class JpaBlogPostsSinkConfiguration {
   @Bean
   BlogPostsSink jpaBlogPostsSink(
       BlogPostEntityRepository repo, 
-      BlogPostEntityMapper mapper
+      BlogPostEntityMapper mapper,
+      JpaEntityGraphQueryBuilder queryBuilder
   ) {
-    return new JpaBlogPostsSink(repo, mapper);
+    return new JpaBlogPostsSink(repo, mapper, queryBuilder);
   }
   
   @Bean
@@ -23,6 +26,13 @@ public class JpaBlogPostsSinkConfiguration {
       AuthorEntityMapper mapper
   ) {
     return new JpaAuthorsSink(repo, mapper);
+  }
+  
+  @Bean
+  JpaEntityGraphQueryBuilder jpaEntityGraphQueryBuilder(
+      EntityManager em
+  ) {
+    return new JpaEntityGraphQueryBuilder(em);
   }
   
 }

--- a/src/main/java/com/samples/spring/persistence/jpa/JpaEntityGraphQueryBuilder.java
+++ b/src/main/java/com/samples/spring/persistence/jpa/JpaEntityGraphQueryBuilder.java
@@ -1,0 +1,28 @@
+package com.samples.spring.persistence.jpa;
+
+import com.samples.spring.domain.BlogPostOptions;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+
+class JpaEntityGraphQueryBuilder {
+
+  private final EntityManager em;
+  
+  JpaEntityGraphQueryBuilder(EntityManager em) {
+    super();
+    this.em = em;
+  }
+
+  TypedQuery<BlogPostEntity> findAllQuery(BlogPostOptions options) {
+    var entityGraph = em
+        .createEntityGraph(BlogPostEntity.class);
+    if(options.isAuthor()) {
+      entityGraph.addSubgraph("author");
+    }
+    return em
+        .createQuery("select b from BlogPost b", BlogPostEntity.class)
+        .setHint("jakarta.persistence.fetchgraph", entityGraph);
+  }
+  
+}

--- a/src/main/java/com/samples/spring/persistence/memory/InMemoryBlogPostsSink.java
+++ b/src/main/java/com/samples/spring/persistence/memory/InMemoryBlogPostsSink.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import com.samples.spring.domain.BlogPost;
+import com.samples.spring.domain.BlogPostOptions;
 import com.samples.spring.domain.BlogPostsSink;
 
 class InMemoryBlogPostsSink
@@ -16,7 +17,7 @@ class InMemoryBlogPostsSink
   private final Map<UUID, BlogPost> blogPosts = new ConcurrentHashMap<>();
 
   @Override
-  public Stream<BlogPost> findAll() {
+  public Stream<BlogPost> findAll(BlogPostOptions options) {
     return this
         .blogPosts
         .values()


### PR DESCRIPTION
We use a JPA EntityGraph to decide whether to join the tables or not. This information is read out from the GraphQl request.
- Tables are joined only if author information is requested. ✅
- The switch has to be sent through the domain, so the domain is affected by this optimization. ⚠️ (https://blog.cleancoder.com/uncle-bob/2018/08/13/TooClean.html)